### PR TITLE
Preserve file extension in copyToLocalTemporaryFile().

### DIFF
--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -287,7 +287,8 @@ class AmazonS3 implements AdapterInterface
     public function copyToLocalTemporaryFile($path)
     {
         $content = $this->read($path);
-        $target = tempnam($this->localTmpDir, null);
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $target = tempnam($this->localTmpDir, null) . '.' . $extension;
 
         file_put_contents($target, $content);
 

--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -205,7 +205,8 @@ class LocalStorage implements AdapterInterface
     public function copyToLocalTemporaryFile($path)
     {
         $content = $this->read($path);
-        $target = tempnam($this->localTmpDir, null);
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $target = tempnam($this->localTmpDir, null) . '.' . $extension;
 
         file_put_contents($target, $content);
 


### PR DESCRIPTION
Some tools -- including `convert` (Imagemagick) and `ffmpeg` -- only work correct if the source file has an extension. This pull request preserves the file extension when copying to a local temporary file.