### PR TITLE
Add acl config option to S3 adaptor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,150 @@ FileSystemBundle is a file system component supporting different file storage ad
 
 This adapter was made to be used when you want to interact with your local file system. 
 
+Config example:
+
+```yml
+    partnermarketing_file_system.default_file_system: local_storage
+    partnermarketing_file_system.config:
+        local_storage:
+            path: /path/to/test/directory
+            url: 'http://your-project-url.dev/test'
+
+```
+
 
 ### Amazon S3
 
-This adapter was made to be used when you want to interacte with Amazon S3 file system.
+This adapter was made to be used when you want to interactive with Amazon S3 file system.
+
+
+Config example:
+
+```yml
+    partnermarketing_file_system.default_file_system: amazon_s3
+    partnermarketing_file_system.config:
+        amazon_s3:
+            key:    your-amazon-key
+            secret: your-amazon-secret
+            bucket: your-bucket-name
+            region: eu-west-1
+            acl:    public-read # Optional parameter.
+
+```
+
+
+## How to use
+
+### Configuration 
+
+First step is to pass the factory into where you need to use it.
+
+```yml
+# In your services.yml
+    YourServiceName:
+        class: Your\Namespace\Path\ServiceName
+        arguments:
+            fileSystemFactory:  @partnermarketing_file_system.factory
+```
+
+Then in your ServiceName.php file you can use the factory as you need.
+
+```php
+
+namespace Your\Namespace\Path;
+
+use Partnermarketing\FileSystemBundle\Factory\FileSystemFactory;
+
+class ServiceName
+{
+    private $fileSystem;
+    
+    public function __construct(FileSystemFactory $fileSystemFactory)
+    {
+        // This will build a fileSystem based on configs specified.
+        $this->filesystem = $fileSystemFactory->build();
+    }
+}
+
+```
+
+
+
+### Read a file content
+
+```php
+$this->filesystem->read($varWithFilePath);
+```
+
+### Write content from a file to other
+
+```php
+// Writes the content of the $source into the $path returns the URL.
+$url = $this->filesystem->write($path, $source);
+```
+
+### Write content into a file
+
+```php
+// Writes the $content into the $path returns the URL:
+$url = $this->filesystem->writeContent($path, $content);
+```
+
+### Delete a file
+
+```php
+// Deletes the file $path:
+$isDeleted = $this->filesystem->writeContent($path);
+```
+
+### Rename a file
+
+```php
+$isRenamed = $this->filesystem->rename($sourcePath, $targetPath);
+```
+
+### Get files from directory
+
+```php
+// Returns an array of files under given directory.
+$filesArray = $this->filesystem->getFiles($directory = '');
+```
+
+### Copy files from one directory to another
+
+```php
+// Copies all files under given source directory to given target directory.
+$filesArray = $this->filesystem->copyFiles($sourceDir, $targetDir);
+```
+
+### Check if a file exist
+
+```php
+$fileExists = $this->filesystem->exists($varWithFilePath);
+```
+
+### Check if path is a directory
+
+```php
+$isDirectory = $this->filesystem->exists($varWithFilePath);
+```
+
+### Gets the Absolute URL to a file
+
+```php
+$absoluteFileUrl = $this->filesystem->getURL($path);
+```
+
+### Copy file to temporary directory
+
+```php
+// Copy a file to the local temporary directory, and return the full path.
+$temporaryFilePath = $this->filesystem->copyToLocalTemporaryFile($path);
+```
+
+
+
+
 
 
 ## How to contribute

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -88,7 +88,7 @@ interface AdapterInterface
     public function isDirectory($path);
 
     /**
-     * Gets the Absoulte URL to an a file
+     * Gets the Absolute URL to an a file
      *
      * @param string $path
      *

--- a/src/Factory/FileSystemFactory.php
+++ b/src/Factory/FileSystemFactory.php
@@ -59,6 +59,18 @@ class FileSystemFactory
         ));
         $fileSystem = new AmazonS3($service , $this->config['amazon_s3']['bucket'], CannedAcl::PUBLIC_READ, $this->tmpDir);
 
+        $acl = CannedAcl::PUBLIC_READ;
+        if (!empty($this->config['amazon_s3']['acl'])) {
+            if(!in_array($this->config['amazon_s3']['acl'], CannedAcl::values())){
+                throw new \Exception('Invalid S3 acl value.');
+            }
+            $acl = $this->config['amazon_s3']['acl'];
+        }
+        $bucket = $this->config['amazon_s3']['bucket'];
+
+        $fileSystem = new AmazonS3($service , $bucket, $acl, $this->tmpDir);
+
+
         return $fileSystem;
     }
 }

--- a/src/Tests/Unit/Factory/FileSystemFactoryTest.php
+++ b/src/Tests/Unit/Factory/FileSystemFactoryTest.php
@@ -42,4 +42,33 @@ class FileSystemFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AmazonS3',
             $this->factory->build('amazon_s3'));
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid S3 acl value.
+     */
+    public function testAmazonConfigAclInvalid()
+    {
+        $this->config = [
+            'local_storage' => ['path' => '', 'url' => ''],
+            'amazon_s3' => ['key' => '', 'secret' => '', 'region' => '', 'bucket' => '', 'acl' => 'read'],
+        ];
+        $this->factory = new FileSystemFactory('amazon_s3', $this->config, '/tmp');
+        $this->factory->build('amazon_s3');
+    }
+
+    /**
+     * Should
+     */
+    public function testAmazonConfigAclValid()
+    {
+        $this->config = [
+            'local_storage' => ['path' => '', 'url' => ''],
+            'amazon_s3' => ['key' => '', 'secret' => '', 'region' => '', 'bucket' => '', 'acl' => 'public-read'],
+        ];
+        $this->factory = new FileSystemFactory('amazon_s3', $this->config, '/tmp');
+
+        $s3Adaptor = $this->factory->build('amazon_s3');
+        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AmazonS3',$s3Adaptor);
+    }
 }


### PR DESCRIPTION
This add ability to set an ACL to be used for S3 adaptor.
Add config examples to use this bundle.

This PR was inspired in https://github.com/partnermarketing/PartnermarketingFileSystemBundle/pull/3
Created by: @AnatolLitnskiy

Thanks for contribution @AnatolLitnskiy. 