### PR TITLE
LocalStorage::delete() should return true if successful.

### DIFF
--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -163,6 +163,7 @@ class LocalStorage implements AdapterInterface
             closedir($handle);
         }
 
+        return true;
     }
 
     /**


### PR DESCRIPTION
This change makes the implementation return what the interface says it will return.