### PR TITLE
Increase scrutinizer-ci timeout.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,4 +3,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 600    # Timeout in seconds.
+        timeout: 1200    # Timeout in seconds.


### PR DESCRIPTION
This will give a bit more time for travis to run the tests and send the phpunit cover report.