### PR TITLE
Ensure getFiles locally recurses, like on S3.

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -51,7 +51,7 @@ interface AdapterInterface
     public function rename($sourcePath, $targetPath);
 
     /**
-     * Returns an array of files under given directory
+     * Returns an array of files under given directory. Recurses into any child directories.
      *
      * @param  string $directory
      * @return array

--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -3,6 +3,7 @@
 namespace Partnermarketing\FileSystemBundle\Adapter;
 
 use Partnermarketing\FileSystemBundle\Exception\FileDoesNotExistException;
+use Partnermarketing\FileSystemBundle\ServerFileSystem\ServerFileSystem;
 
 /**
  * LocalStorage specific file system adapter
@@ -112,22 +113,11 @@ class LocalStorage implements AdapterInterface
     {
         $directory = $this->pathOrUrlToPath($directory);
 
-        $array = [];
+        $files = ServerFileSystem::getFilesInDirectory($this->absolutePath . '/' . $directory);
 
-        if ($handle = opendir($this->absolutePath.'/'.$directory)) {
-            while (false !== ($entry = readdir($handle))) {
-                if ($entry != "." && $entry != "..") {
-                    if (!empty($directory)) {
-                        $array[] = $directory.'/'.$entry;
-                    } else {
-                        $array[] = $entry;
-                    }
-                }
-            }
-            closedir($handle);
-        }
-
-        return $array;
+        return array_map(function ($file) {
+            return str_replace($this->absolutePath . '/', '', $file);
+        }, $files);
     }
 
     public function mkdir($dir)

--- a/src/Tests/Unit/Adapter/LocalStorageTest.php
+++ b/src/Tests/Unit/Adapter/LocalStorageTest.php
@@ -32,4 +32,12 @@ class LocalStorageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedSize, $actualSize);
     }
+
+    public function testGetFiles()
+    {
+        $result = $this->adapter->getFiles();
+
+        $this->assertCount(3, $result);
+        $this->assertContains('sub-dir/test2.txt', $result);
+    }
 }

--- a/src/Tests/Unit/ServerFileSystem/ServerFileSystemTest.php
+++ b/src/Tests/Unit/ServerFileSystem/ServerFileSystemTest.php
@@ -17,9 +17,9 @@ class ServerFileSystemTest extends \PHPUnit_Framework_TestCase
     {
         $files = ServerFileSystem::getFilesInDirectory(__DIR__  . '/../');
 
-        $this->assertCount(5, $files);
+        $this->assertCount(6, $files);
         $this->assertStringEndsWith('Unit/Adapter/LocalStorageTest.php', $files[0]);
-        $this->assertStringEndsWith('Unit/Factory/FileSystemFactoryTest.php', $files[2]);
+        $this->assertStringEndsWith('Unit/Factory/FileSystemFactoryTest.php', $files[3]);
     }
 
     public function testDeleteFilesInDirectoryRecursively()


### PR DESCRIPTION
In the previous implementation, getFiles in the LocalStorage adapter would not recurse into child directories.