### PR TITLE
Set up a default for temp files

### DIFF
--- a/src/Factory/FileSystemFactory.php
+++ b/src/Factory/FileSystemFactory.php
@@ -16,11 +16,11 @@ class FileSystemFactory
     private $config;
     private $tmpDir;
 
-    public function __construct($defaultFileSystem, $config, $tmpDir)
+    public function __construct($defaultFileSystem, $config, $tmpDir = null)
     {
         $this->defaultFileSystem = $defaultFileSystem;
         $this->config = $config;
-        $this->tmpDir = $tmpDir;
+        $this->tmpDir = $tmpDir ?: sys_get_temp_dir();
     }
 
     /**


### PR DESCRIPTION
Sometimes, a developer might not necessarily know a good temporary file location, and would like to use the PHP configured default. This change makes the `$tmpDir` argument of `FileSystemFactory` optional, defaulting to the php.ini configured temporary file location.