### PR TITLE
Allow access to underlying service in adapters

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -106,4 +106,11 @@ interface AdapterInterface
      * @return string Path to the copied temporary file.
      */
     public function copyToLocalTemporaryFile($path);
+    
+    /**
+     * Gets the internal provider used for communication with the configured filesystem.
+     * 
+     * @return object The S3Client or SymfonyFileSystem object currently in-use
+     */
+    public function getService();
 }

--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -305,6 +305,13 @@ class AmazonS3 implements AdapterInterface
 
         return $target;
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getService() {
+        return $this->service;
+    }
 
     /**
      * Returns an s3 location in normalised format, plus parses the bucket name

--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -221,6 +221,13 @@ class LocalStorage implements AdapterInterface
 
         return $target;
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getService() {
+        return $this->service;
+    }
 
     /**
      * @param  string $input

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -147,6 +147,13 @@ class FileSystem implements AdapterInterface
     {
         return $this->adapter->copyToLocalTemporaryFile($path);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getService() {
+        return $this->adapter->getService();
+    }
 
     /**
      * Checks if a file exists, throws an error if it doesn't.


### PR DESCRIPTION
Allowing access to the underlying `Symfony\Component\Filesystem\Filesystem` or `Aws\S3\S3Client` gives the developer a way to re-use their configuration for FileSystemBundle if they want to extend it's functionality in their own code.