### PR TITLE
Add time-limited URL functionality

### DIFF
--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -92,6 +92,15 @@ interface AdapterInterface
     public function getURL($path);
 
     /**
+     * Gets the absolute URL to the file at $path that will expire
+     *
+     * @param  string $path
+     * @param  string|integer|\DateTime $expiresAt
+     * @return string URL to the file.
+     */
+    public function getExpiringURL($path, $expiresAt);
+
+    /**
      * Gets the size, in bytes, of the file at $path.
      *
      * @param  string $path

--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -282,6 +282,23 @@ class AmazonS3 implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    public function getExpiringURL($path, $expiresAt)
+    {
+        list($path, $bucket) = $this->pathOrUrlToPath($path);
+        
+        $command = $this->service->getCommand('GetObject', [
+            'Bucket' => $bucket,
+            'Key'    => $path
+        ]);
+        
+        $request = $this->service->createPresignedRequest($command, $expiresAt);
+        
+        return (string) $request->getUri();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getFileSize($path)
     {
         list($path, $bucket) = $this->pathOrUrlToPath($path);

--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -197,6 +197,14 @@ class LocalStorage implements AdapterInterface
 
         return $this->webUrl.'/'.$path;
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getExpiringURL($path, $expiresAt) {
+        // Local storage cannot provide expiring URLs. Falling back...
+        return $this->getURL($path);
+    }
 
     /**
      * {@inheritDoc}

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -135,6 +135,14 @@ class FileSystem implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    public function getExpiringURL($path, $expiresAt)
+    {
+        return $this->adapter->getExpiringURL($path, $expiresAt);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getFileSize($path)
     {
         return $this->adapter->getFileSize($path);


### PR DESCRIPTION
A very common use case on S3 is to upload an item with `private` ACL, and give individual users you want access to the file via a time-limited "signed URL".

These changes add the ability to generate a signed URL on S3, falling back to providing the normal URL for the local adapter. 