### PR TITLE
Ensure there are no regressions on PSR Standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
     - php composer.phar install
 
 script:
+    - vendor/squizlabs/php_codesniffer/scripts/phpcs --standard=PSR2 -p src/
     - vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7",
-        "johnkary/phpunit-speedtrap": "dev-master"
+        "johnkary/phpunit-speedtrap": "dev-master",
+        "partnermarketing/pm-git-hooks-php": "^1.0"
     }
 }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -109,7 +109,7 @@ interface AdapterInterface
     
     /**
      * Gets the internal provider used for communication with the configured filesystem.
-     * 
+     *
      * @return object The S3Client or SymfonyFileSystem object currently in-use
      */
     public function getService();

--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -25,7 +25,7 @@ class AmazonS3 implements AdapterInterface
      * @param string           $acl
      * @param array            $options
      */
-    public function __construct(AmazonClient $service, $bucket, $acl = 'public-read', $localTmpDir, $options = array())
+    public function __construct(AmazonClient $service, $bucket, $localTmpDir, $acl = 'public-read', $options = array())
     {
         $this->service = $service;
         $this->bucket  = $bucket;
@@ -305,7 +305,7 @@ class AmazonS3 implements AdapterInterface
 
         return $target;
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -309,7 +309,8 @@ class AmazonS3 implements AdapterInterface
     /**
      * {@inheritDoc}
      */
-    public function getService() {
+    public function getService()
+    {
         return $this->service;
     }
 

--- a/src/Adapter/LocalStorage.php
+++ b/src/Adapter/LocalStorage.php
@@ -225,7 +225,8 @@ class LocalStorage implements AdapterInterface
     /**
      * {@inheritDoc}
      */
-    public function getService() {
+    public function getService()
+    {
         return $this->service;
     }
 

--- a/src/Command/FindCommand.php
+++ b/src/Command/FindCommand.php
@@ -32,7 +32,9 @@ class FindCommand extends ContainerAwareCommand
     {
         $adapterName = $input->getArgument('adapter');
         if (!in_array($adapterName, $this->availableAdapters)) {
-            $output->writeln('Invalid adapter name supplied! Adapters available: ' . implode(', ', $this->availableAdapters));
+            $output->writeln(
+                'Invalid adapter name supplied! Adapters available: ' . implode(', ', $this->availableAdapters)
+            );
 
             return;
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 /**
  * This is the class that validates and merges configuration from your app/config files
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * To learn more see:
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class
  */
 class Configuration implements ConfigurationInterface
 {

--- a/src/Exception/FileDoesNotExistException.php
+++ b/src/Exception/FileDoesNotExistException.php
@@ -16,5 +16,4 @@ class FileDoesNotExistException extends \RuntimeException
             $previous
         );
     }
-
 }

--- a/src/Factory/FileSystemFactory.php
+++ b/src/Factory/FileSystemFactory.php
@@ -38,7 +38,10 @@ class FileSystemFactory
             case 'amazon_s3':
                 return $this->buildAmazonS3FileSystem();
             default:
-                throw new \Exception('The configuration for default_file_system needs to be set in the parameters.yml or the given adapter name did not match any existing file system');
+                throw new \Exception(
+                    'The configuration for default_file_system needs to be set in the parameters.yml'
+                    .' or the given adapter name did not match any existing file system'
+                );
         }
     }
 
@@ -59,7 +62,7 @@ class FileSystemFactory
             'region' => $this->config['amazon_s3']['region'],
             'version' => '2006-03-01'
         ));
-        $fileSystem = new AmazonS3($service , $this->config['amazon_s3']['bucket'], 'public-read', $this->tmpDir);
+        $fileSystem = new AmazonS3($service, $this->config['amazon_s3']['bucket'], 'public-read', $this->tmpDir);
 
         $acl = 'public-read';
         $allowedValues = [
@@ -71,14 +74,14 @@ class FileSystemFactory
             'bucket-owner-full-control'
         ];
         if (!empty($this->config['amazon_s3']['acl'])) {
-            if(!in_array($this->config['amazon_s3']['acl'], $allowedValues)){
+            if (!in_array($this->config['amazon_s3']['acl'], $allowedValues)) {
                 throw new \Exception('Invalid S3 acl value.');
             }
             $acl = $this->config['amazon_s3']['acl'];
         }
         $bucket = $this->config['amazon_s3']['bucket'];
 
-        $fileSystem = new AmazonS3($service , $bucket, $acl, $this->tmpDir);
+        $fileSystem = new AmazonS3($service, $bucket, $acl, $this->tmpDir);
 
 
         return $fileSystem;

--- a/src/Factory/FileSystemFactory.php
+++ b/src/Factory/FileSystemFactory.php
@@ -62,7 +62,7 @@ class FileSystemFactory
             'region' => $this->config['amazon_s3']['region'],
             'version' => '2006-03-01'
         ));
-        $fileSystem = new AmazonS3($service, $this->config['amazon_s3']['bucket'], 'public-read', $this->tmpDir);
+        $fileSystem = new AmazonS3($service, $this->config['amazon_s3']['bucket'], $this->tmpDir, 'public-read');
 
         $acl = 'public-read';
         $allowedValues = [
@@ -81,7 +81,7 @@ class FileSystemFactory
         }
         $bucket = $this->config['amazon_s3']['bucket'];
 
-        $fileSystem = new AmazonS3($service, $bucket, $acl, $this->tmpDir);
+        $fileSystem = new AmazonS3($service, $bucket, $this->tmpDir, $acl);
 
 
         return $fileSystem;

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -151,7 +151,8 @@ class FileSystem implements AdapterInterface
     /**
      * {@inheritDoc}
      */
-    public function getService() {
+    public function getService()
+    {
         return $this->adapter->getService();
     }
 
@@ -167,5 +168,4 @@ class FileSystem implements AdapterInterface
             throw new FileDoesNotExistException($path);
         }
     }
-
 }

--- a/src/Tests/Unit/Factory/FileSystemFactoryTest.php
+++ b/src/Tests/Unit/Factory/FileSystemFactoryTest.php
@@ -27,20 +27,26 @@ class FileSystemFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildDefault()
     {
-        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AdapterInterface',
-            $this->factory->build());
+        $this->assertInstanceOf(
+            'Partnermarketing\FileSystemBundle\Adapter\AdapterInterface',
+            $this->factory->build()
+        );
     }
 
     public function testBuildLocalStorage()
     {
-        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\LocalStorage',
-            $this->factory->build('local_storage'));
+        $this->assertInstanceOf(
+            'Partnermarketing\FileSystemBundle\Adapter\LocalStorage',
+            $this->factory->build('local_storage')
+        );
     }
 
     public function testBuildAmazonS3()
     {
-        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AmazonS3',
-            $this->factory->build('amazon_s3'));
+        $this->assertInstanceOf(
+            'Partnermarketing\FileSystemBundle\Adapter\AmazonS3',
+            $this->factory->build('amazon_s3')
+        );
     }
 
     /**
@@ -69,7 +75,7 @@ class FileSystemFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory = new FileSystemFactory('amazon_s3', $this->config, '/tmp');
 
         $s3Adaptor = $this->factory->build('amazon_s3');
-        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AmazonS3',$s3Adaptor);
+        $this->assertInstanceOf('Partnermarketing\FileSystemBundle\Adapter\AmazonS3', $s3Adaptor);
     }
     
     public function testDefaultsTempDirCorrectly()
@@ -97,6 +103,6 @@ class FileSystemFactoryTest extends \PHPUnit_Framework_TestCase
         
         $adapter->delete($initFile);
         $adapter->delete($tmpFile);
-        $adapter->delete(substr($tmpFile, 0 , (strrpos($tmpFile, "."))));
+        $adapter->delete(substr($tmpFile, 0, (strrpos($tmpFile, "."))));
     }
 }


### PR DESCRIPTION
- [x] Ensure builds fail when PSR2 standards are not met
- [x] Fix existing PSR2 standards issues

Error:
```sh
FILE: ...keting/PartnermarketingFileSystemBundle/src/Adapter/AmazonS3.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 28 | ERROR | Arguments with default values must be at the end of the
    |       | argument list
----------------------------------------------------------------------
```

This will require a major bump on this package.
Make sure we do a release before merging this PR to ensure who is using previous major version gets the latest features that are still compatible with their versions.