### PR TITLE
Hotfix: Fix waitUntil() methods

### DIFF
--- a/src/Adapter/AmazonS3.php
+++ b/src/Adapter/AmazonS3.php
@@ -88,7 +88,7 @@ class AmazonS3 implements AdapterInterface
             'ContentType' => Mimetypes::getInstance()->fromFilename($path)
         ));
 
-        $this->service->waitUntilObjectExists(array(
+        $this->service->waitUntil('ObjectExists', array(
             'Bucket' => $bucket,
             'Key'    => $path
         ));
@@ -255,7 +255,7 @@ class AmazonS3 implements AdapterInterface
             array('Bucket' => $this->bucket, 'LocationConstraint' => $this->options['region'])
         );
 
-        $this->service->waitUntilBucketExists(array('Bucket' => $this->bucket));
+        $this->service->waitUntil('BucketExists', array('Bucket' => $this->bucket));
 
         if (!$response['Location']) {
             throw new \RuntimeException(sprintf(


### PR DESCRIPTION
Fix which will need to be applied to versions 2 and 3. I have created branches for those and I suggest we cherry pick this commit to both of those branches and then release two new patch versions immediately: 2.1.1 and 3.0.2 (in theory, we should do 2.0.1 as well... not sure if we can be bothered to apply patches to that level)