### PR TITLE
Lock speedstrap version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0 | ~5.0",
-        "johnkary/phpunit-speedtrap": "dev-master",
+        "johnkary/phpunit-speedtrap": "~1.0.0",
         "partnermarketing/pm-git-hooks-php": "^1.0"
     }
 }


### PR DESCRIPTION
#31 is failing on PHP 5.5 because the latest version of jonkary/phpunit-speedtrap requires >=5.6. We were tracking its develop branch so I've locked it down to a stable version.