### PR TITLE
Fix delete file documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $url = $this->filesystem->writeContent($path, $content);
 
 ```php
 // Deletes the file $path:
-$isDeleted = $this->filesystem->writeContent($path);
+$isDeleted = $this->filesystem->delete($path);
 ```
 
 ### Rename a file


### PR DESCRIPTION
The delete file functionality was incorrectly documented as `writeContent()` function rather than the correct `delete()` function.